### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plugin-sdk-release.yml
+++ b/.github/workflows/plugin-sdk-release.yml
@@ -41,6 +41,8 @@ jobs:
           version: latest
           working-directory: packages/plugin-sdk
   release:
+    permissions:
+      contents: write
     needs: test
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/plugin-sdk-release.yml
+++ b/.github/workflows/plugin-sdk-release.yml
@@ -1,4 +1,6 @@
 name: Plugin SDK Release
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/jameswlane/devex/security/code-scanning/18](https://github.com/jameswlane/devex/security/code-scanning/18)

To fix this issue, the workflow should explicitly declare a `permissions` block, either at the root level (applying to all jobs unless overridden) or at each job (for more granularity). The safest and simplest route is to add a root-level `permissions` block with the least-privilege settings. For this workflow, most jobs only require read permissions (`contents: read`), but the `release` job likely requires `contents: write` to create releases or push tags. Unless more granular permissions are needed for each job, adding `permissions: contents: read` at the root is a minimal starting point. If the release job needs write access, it can be overridden at the job level.

You will need to:
- Add a root-level `permissions` block at line 2, right after the `name` declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
