### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -340,6 +340,7 @@ jobs:
     needs: [detect-plugins, build-plugin, release-plugins, update-registry]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Build Summary
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/jameswlane/devex/security/code-scanning/15](https://github.com/jameswlane/devex/security/code-scanning/15)

To address this, add an explicit `permissions` block to the `build-summary` job (lines 339–383). Since this job only writes a job summary and does not interact with the GitHub API or repository contents, the highest restriction is to set `permissions: {}` in the job. This removes all permissions for the GITHUB_TOKEN in that job. To implement, add the block:

```yaml
    permissions: {}
```

directly beneath the `runs-on:` key in the `build-summary` job definition (so, after line 342 and before steps), following YAML best practices and the conventions already used for permissions in other jobs in the file.

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
