### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plugin-update.yml
+++ b/.github/workflows/plugin-update.yml
@@ -1,4 +1,6 @@
 name: Parallel Plugin Build and Deploy
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/jameswlane/devex/security/code-scanning/14](https://github.com/jameswlane/devex/security/code-scanning/14)

To fix this problem, add an explicit `permissions` block to limit the GITHUB_TOKEN permissions for jobs that do not need write access. The ideal place for this is at the workflow root, so it applies to all jobs by default. If any job needs more permissions (as is already the case for `release-plugins`), that job can override the inherited permissions block. For this workflow, `detect-plugins` and `build-plugin` only read repository contents, build, and upload artifacts, so they do not need write access. Therefore, set `permissions: contents: read` at the workflow root, which is the single cleanest change. No other methods, imports, or definitions are needed; it's a single edit to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
